### PR TITLE
Elasticsearch 6.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,29 @@
+dist: trusty
+sudo: required
 language: ruby
-rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-services:
-  - elasticsearch
+matrix:
+  include:
+    - rvm: 2.3.3
+      jdk: oraclejdk8
+      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
+
+    - rvm: 2.2.6
+      jdk: oraclejdk8
+      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
+
+    - rvm: 2.4.0
+      jdk: oraclejdk8
+      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
+
+before_install:
+  - gem update --system
+  - gem --version
+  - gem install bundler -v 1.14.3
+  - bundle version
+  - curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz | tar xz -C /tmp
+
+install:
+  - bundle install
+
+script:
+  - make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@ matrix:
   include:
     - rvm: 2.3.3
       jdk: oraclejdk8
-      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
 
     - rvm: 2.2.6
       jdk: oraclejdk8
-      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
 
     - rvm: 2.4.0
       jdk: oraclejdk8
-      env: PATH=/tmp/elasticsearch-6.0.0/bin/elasticsearch:${PATH}
 
 before_install:
   - gem update --system
@@ -26,4 +23,4 @@ install:
   - bundle install
 
 script:
-  - make travis
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
+language: ruby
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
 services:
   - elasticsearch

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'elasticsearch', github: 'pkarman/elasticsearch-ruby', branch: '6.x-aliases'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'elasticsearch', github: 'pkarman/elasticsearch-ruby', branch: '6.x-aliases'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-test:
+test6:
 	PATH=/tmp/elasticsearch-6.0.0/bin:${PATH} rake test
 
-.PHONY: test
+test5:
+	PATH=/tmp/elasticsearch-5.0.0/bin:${PATH} rake test
+
+test2:
+	PATH=/tmp/elasticsearch-2.4.6/bin:${PATH} rake test
+
+test: test6
+
+.PHONY: test test5 test6 test2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	ES_PATH_CONF=/tmp/es-config/ PATH=/usr/share/elasticsearch/bin/:${PATH} rake test
+
+travis:
+	rake test
+
+.PHONY: test travis

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 test:
-	ES_PATH_CONF=/tmp/es-config/ PATH=/usr/share/elasticsearch/bin/:${PATH} rake test
+	PATH=/tmp/elasticsearch-6.0.0/bin:${PATH} rake test
 
-travis:
-	rake test
-
-.PHONY: test travis
+.PHONY: test

--- a/elasticsearch-indexstager.gemspec
+++ b/elasticsearch-indexstager.gemspec
@@ -7,22 +7,21 @@ Gem::Specification.new do |s|
   s.name          = 'elasticsearch-indexstager'
   s.version       = Elasticsearch::IndexStager::VERSION
   s.authors       = ['Peter Karman']
-  s.email         = ['peter.karman@gsa.gov']
+  s.email         = ['karpet@peknet.com']
   s.summary       = 'manage Elasticsearch indexes using staging pattern'
   s.description   = (
     'manage Elasticsearch indexes using staging pattern'
   )
-  s.homepage      = 'https://github.com/18F/elasticsearch-indexstager-gem'
+  s.homepage      = 'https://github.com/karpet/elasticsearch-indexstager-gem'
   s.license       = 'CC0'
 
   s.files         = `git ls-files -z *.md bin lib`.split("\x0") + [
   ]
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'elasticsearch'
+  #s.add_runtime_dependency 'elasticsearch', '~> 6.0'
 
   s.required_ruby_version = ">= 1.9.3"
-  s.add_development_dependency 'about_yml'
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/elasticsearch-indexstager.gemspec
+++ b/elasticsearch-indexstager.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   ]
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  #s.add_runtime_dependency 'elasticsearch', '~> 6.0'
+  s.add_runtime_dependency 'elasticsearch', '~> 6.0'
 
   s.required_ruby_version = ">= 1.9.3"
   s.add_development_dependency "bundler", "~> 1.3"

--- a/lib/elasticsearch/index_stager.rb
+++ b/lib/elasticsearch/index_stager.rb
@@ -1,6 +1,8 @@
+require 'securerandom'
+
 module Elasticsearch
   class IndexStager
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
 
     attr_reader :index_name, :es_client
 
@@ -33,13 +35,21 @@ module Elasticsearch
       # the renaming actions (performed atomically by ES)
       rename_actions = [ 
         { remove: { index: stage_aliased_to, alias: stage_index_name } },
-        {    add: { index: stage_index_name, alias: @live_index_name } } 
+        {    add: { index: stage_aliased_to, alias: @live_index_name } } 
       ]   
 
       # zap any existing index known as index_name,
       # but do it conditionally since it is reasonable that it does not exist.
       to_delete = []
-      existing_live_index = es_client.indices.get_aliases(index: @live_index_name)
+      live_index_exists = false
+      begin
+        existing_live_index = es_client.indices.get_aliases(index: @live_index_name, name: '*')
+        live_index_exists = true
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => _err
+        existing_live_index = {}
+      rescue => _err
+        raise _err
+      end
       existing_live_index.each do |k,v|
 
         # if the index is merely aliased, remove its alias as part of the aliasing transaction.
@@ -50,11 +60,16 @@ module Elasticsearch
           to_delete.push k
 
         else
-          # this is a real, unaliased index with this name, so it must be deleted.
-          # (This usually happens the first time we implement the aliasing scheme against
-          # an existing installation.)
-          es_client.indices.delete index: @live_index_name rescue false
+          raise "Found existing index called #{@live_index_name} aliased to itself"
         end
+      end
+
+      if live_index_exists
+        new_name = @live_index_name + '-pre-staged-original'
+        # make a copy
+        es_client.reindex body: { source: { index: @live_index_name }, dest: { index: new_name } }
+        # delete the original
+        es_client.indices.delete index: @live_index_name rescue false
       end
 
       # re-alias
@@ -80,7 +95,7 @@ module Elasticsearch
 
     def find_newest_alias_for(the_index_name)
       aliased_to = nil
-      aliases = es_client.indices.get_aliases(index: the_index_name)
+      aliases = es_client.indices.get_aliases(index: the_index_name, name: '*')
       aliases.each do |k,v|
         next unless k.match(tmp_index_pattern)
         aliased_to ||= k

--- a/lib/elasticsearch/index_stager.rb
+++ b/lib/elasticsearch/index_stager.rb
@@ -43,7 +43,7 @@ module Elasticsearch
       to_delete = []
       live_index_exists = false
       begin
-        existing_live_index = es_client.indices.get_aliases(index: @live_index_name, name: '*')
+        existing_live_index = es_client.indices.get_alias(index: @live_index_name, name: '*')
         live_index_exists = true
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => _err
         existing_live_index = {}
@@ -95,7 +95,7 @@ module Elasticsearch
 
     def find_newest_alias_for(the_index_name)
       aliased_to = nil
-      aliases = es_client.indices.get_aliases(index: the_index_name, name: '*')
+      aliases = es_client.indices.get_alias(index: the_index_name, name: '*')
       aliases.each do |k,v|
         next unless k.match(tmp_index_pattern)
         aliased_to ||= k

--- a/spec/index_stager_spec.rb
+++ b/spec/index_stager_spec.rb
@@ -38,8 +38,13 @@ describe Elasticsearch::IndexStager do
     stager.promote
     ESHelper.refresh(stager.index_name)
 
-    aliases = ESHelper.client.indices.get_aliases(index: stager.index_name)
+    aliases = ESHelper.client.indices.get_aliases(index: stager.index_name, name: '*')
     expect(aliases.keys[0]).to eq stager.tmp_index_name
+
+    # the original was saved
+    orig_name = stager.index_name + '-pre-staged-original'
+    resp = ESHelper.client.search(index: orig_name, body: { query: { match: { title: 'test' } } } )
+    expect(resp['hits']['total']).to eq 2
   end
 
   def create_index(index_name)

--- a/spec/index_stager_spec.rb
+++ b/spec/index_stager_spec.rb
@@ -5,7 +5,6 @@ describe Elasticsearch::IndexStager do
 
   def delete_all_indices
     indices = ESHelper.client.indices.get_aliases
-    pp indices
     ESHelper.client.indices.delete(index: indices.keys) if indices.keys.any?
   end
 


### PR DESCRIPTION
The ES API changed between 1.x and 6.x to add the `get_alias` endpoint.